### PR TITLE
Ensure type parity when comparing paid amount and order total

### DIFF
--- a/src/controllers/CallbackController.php
+++ b/src/controllers/CallbackController.php
@@ -177,7 +177,8 @@ class CallbackController extends Controller
         $childTransaction = Plugin::getInstance()->getTransactions()->createTransaction(null, $transaction);
 
         if ($response->isExpress()) {
-            $amount = $response->getAmount(false) / 100;
+            // Make sure the amount is a float/double for the comparison below
+            $amount = $response->getAmount(false) / 100.0;
 
             // Make sure the amount is correct since it can change on the Vipps side
             // when customer selects shipping method


### PR DESCRIPTION
This assumes Order::getTotalPrice() always returns float (it does in latest Craft Commerce)